### PR TITLE
Image optimization correctness bug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub mod bits;
 pub mod color;
 pub mod compress;
 pub mod error;
+pub mod paeth;
 pub mod jpeg;
 pub mod png;
 

--- a/src/paeth.rs
+++ b/src/paeth.rs
@@ -1,0 +1,26 @@
+//! Paeth predictor in a feature-agnostic module.
+//!
+//! This scalar implementation is used by PNG filtering and remains available
+//! regardless of whether SIMD acceleration is enabled. SIMD paths delegate to
+//! this predictor to ensure consistent behavior across feature combinations.
+
+/// Scalar Paeth predictor (PNG spec).
+#[inline]
+pub fn paeth_predictor(a: u8, b: u8, c: u8) -> u8 {
+    let a = a as i16;
+    let b = b as i16;
+    let c = c as i16;
+
+    let p = a + b - c;
+    let pa = (p - a).abs();
+    let pb = (p - b).abs();
+    let pc = (p - c).abs();
+
+    if pa <= pb && pa <= pc {
+        a as u8
+    } else if pb <= pc {
+        b as u8
+    } else {
+        c as u8
+    }
+}

--- a/src/png/filter.rs
+++ b/src/png/filter.rs
@@ -9,6 +9,7 @@ use rayon::prelude::*;
 
 #[cfg(feature = "simd")]
 use crate::simd;
+use crate::paeth;
 
 /// Scratch buffers reused for adaptive filtering to reduce per-row allocations.
 struct AdaptiveScratch {
@@ -277,7 +278,7 @@ fn filter_paeth(row: &[u8], prev_row: &[u8], bpp: usize, output: &mut Vec<u8>) {
 #[allow(dead_code)]
 #[inline]
 fn paeth_predictor(a: u8, b: u8, c: u8) -> u8 {
-    crate::simd::fallback::fallback_paeth_predictor(a, b, c)
+    paeth::paeth_predictor(a, b, c)
 }
 
 /// Adaptive filter selection: try all filters and pick the best.

--- a/src/simd/fallback.rs
+++ b/src/simd/fallback.rs
@@ -140,20 +140,5 @@ pub fn filter_paeth(row: &[u8], prev_row: &[u8], bpp: usize, output: &mut Vec<u8
 /// Scalar Paeth predictor used by both fallback and tests.
 #[inline]
 pub fn fallback_paeth_predictor(a: u8, b: u8, c: u8) -> u8 {
-    let a = a as i16;
-    let b = b as i16;
-    let c = c as i16;
-
-    let p = a + b - c;
-    let pa = (p - a).abs();
-    let pb = (p - b).abs();
-    let pc = (p - c).abs();
-
-    if pa <= pb && pa <= pc {
-        a as u8
-    } else if pb <= pc {
-        b as u8
-    } else {
-        c as u8
-    }
+    crate::paeth::paeth_predictor(a, b, c)
 }


### PR DESCRIPTION
Refactor PNG Paeth predictor to be feature-agnostic, fixing build breaks when the `simd` feature is disabled.

Previously, the `png::filter::paeth_predictor` unconditionally relied on a SIMD fallback implementation. This caused a build failure when compiling without default features (which disables SIMD), as the `simd` module was not available. This PR extracts the scalar Paeth predictor into its own module, making it accessible to all build configurations and ensuring consistent behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-68084505-1930-4a16-b2fb-ed0cdf42a838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-68084505-1930-4a16-b2fb-ed0cdf42a838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

