### PR TITLE
Rust build optimization mac

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -150,6 +150,25 @@ cargo bench --bench comparison -- --baseline my-machine
 
 ## Performance Tips
 
+### macOS Build Optimization
+
+On macOS, the XProtect antivirus scans every new executable on first run. This significantly slows down:
+- **Build scripts**: Each is scanned before execution
+- **`cargo run`**: Every rebuild triggers a scan
+- **`cargo test`**: Each test binary is scanned (can cause 2-3x slowdown!)
+
+**Workaround**: Add your terminal app as a "developer tool" in System Settings:
+
+1. Open **System Settings** → **Privacy & Security** → **Developer Tools**
+2. Add **Terminal** (or iTerm, Alacritty, etc.) to the list
+3. **Restart your terminal** for the change to take effect
+
+This disables XProtect scanning for executables launched from your terminal. Note that this is a security trade-off—only do this if you're comfortable with the implications.
+
+**References**:
+- [Faster Rust builds on Mac](https://nnethercote.github.io/2025/09/04/faster-rust-builds-on-mac.html) by Nicholas Nethercote
+- [cargo-nextest docs](https://nexte.st/docs/configuration/macos/)
+
 ### For Benchmarking
 
 1. **Use release mode**: `cargo bench` automatically uses release optimizations


### PR DESCRIPTION
Add macOS build optimization tips to `benches/README.md` to improve local Rust build and test times.

macOS XProtect scans every new executable, which significantly slows down `cargo build`, `cargo run`, and `cargo test`. This PR documents a workaround to add the terminal app as a "developer tool" to disable these scans for executables launched from the terminal.

---
<a href="https://cursor.com/background-agent?bcId=bc-f77552f5-e2aa-46fb-b645-9bf44c1e384a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f77552f5-e2aa-46fb-b645-9bf44c1e384a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

